### PR TITLE
bug fix _store init

### DIFF
--- a/ttl.js
+++ b/ttl.js
@@ -6,7 +6,7 @@ var timer = null;
 
 function Ttl(options) {
 
-	this._store = [];
+	this._store = {};
 
 	this.options = {
 		ttl: 0,


### PR DESCRIPTION
this._store = {}; initiated as array but used as hash object in code
