### PR TITLE
unref timer

### DIFF
--- a/ttl.js
+++ b/ttl.js
@@ -48,6 +48,7 @@ function Ttl(options) {
 				self._check(obj);
 			}
 		}, this.options.checkPeriode);
+		timer.unref();
 	}
 }
 


### PR DESCRIPTION
unref timer, so Node.js not to hold the current process open if the given timer is the only thing left to execute on the event-loop queue